### PR TITLE
feat: export types & add more gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+yarn.lock
+pnpm-lock.yaml
+.DS_Store
+*.log
+
 .history
 node_modules
 dist

--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,8 @@ import { AfdianApiOpts } from './src/types/common';
 import { AfdianBasicResponse, AfdianOrderResponse, AfdianRequestParams, AfdianSponsorResponse } from './src/types/request';
 import { buildRequest, signRequest } from './src/utils/request';
 
+export * from './src/types'
+
 class AfdianApi {
   private userId: string;
   private token: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './common'
+export * from './request'


### PR DESCRIPTION
I think we should export types for developers to import it when use ts.

And other package manager lock ignore & `.DS_Store` for mac.